### PR TITLE
feat: use the new Stackblitz editor

### DIFF
--- a/src/server/routes/s/[slug].get.ts
+++ b/src/server/routes/s/[slug].get.ts
@@ -7,5 +7,5 @@ export default defineEventHandler(async event => {
       body: 'Not found'
     }
   }
-  return sendRedirect(event, `https://stackblitz.com/github/${starter.repo}/tree/${starter.branch}/${starter.dir || ''}`, 302)
+  return sendRedirect(event, `https://stackblitz.com/~/github/${starter.repo}/tree/${starter.branch}/${starter.dir || ''}`, 302)
 })


### PR DESCRIPTION
Current: https://stackblitz.com/github/nuxt/starter/tree/v3/
New: https://stackblitz.com/~/github.com/nuxt/starter/tree/v3

`https://stackblitz.com/~/` is the new editor used in Codeflow, which features full VS Code experience. To provide better DX, I think we should recommend it for playing with Nuxt.

/cc @patak-dev