### PR TITLE
ci: restrict ci workflow permissions to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Small hardening change: set `permissions: contents: read` at the top of `.github/workflows/ci.yml` so the workflow token is read-only instead of inheriting the repository default. The job only does checkout and build/test, so nothing else is required.